### PR TITLE
Add height and width to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,16 @@ declare class VideoStreamMerger {
   constructor(options?: Partial<VideoStreamMerger.ConstructorOptions>);
 
   /**
+   * Height of the merged MediaStream
+   */
+  height: number;
+
+  /**
+   * Width of the merged MediaStream
+   */
+  width: number;
+
+  /**
    * The resulting merged MediaStream. Only available after calling merger.start()
    * Never has more than one Audio and one Video track.
    */


### PR DESCRIPTION
The height and width properties were missing from the type definitions.