### PR TITLE
fix(result): change height computation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class VideoStreamMerger {
   setOptions(options: Partial<ConstructorOptions> = {}): void {
     this._audioCtx = (options.audioContext || new AudioContext());
     this.width = options.width || this.width;
-    this.height = options.height || this.width;
+    this.height = options.height || this.height;
     this.fps = options.fps || this.fps;
     this.clearRect = options.clearRect === undefined ? true : options.clearRect;
   }


### PR DESCRIPTION
this.height was replaced by this.width in case of option absence.